### PR TITLE
ENH: embedded tags

### DIFF
--- a/fail2ban/server/action.py
+++ b/fail2ban/server/action.py
@@ -379,7 +379,6 @@ class CommandAction(ActionBase):
 			within the values recursively replaced.
 		"""
 		t = re.compile(r'<([^ >]+)>')
-		tlr = re.compile(r'[<>]')
 		for tag in tags.iterkeys():
 			if tag in cls._escapedTags:
 				# Escaped so won't match

--- a/fail2ban/server/action.py
+++ b/fail2ban/server/action.py
@@ -379,6 +379,7 @@ class CommandAction(ActionBase):
 			within the values recursively replaced.
 		"""
 		t = re.compile(r'<([^ >]+)>')
+		tlr = re.compile(r'[<>]')
 		for tag in tags.iterkeys():
 			if tag in cls._escapedTags:
 				# Escaped so won't match
@@ -402,7 +403,17 @@ class CommandAction(ActionBase):
 						value = value.replace('<%s>' % found_tag , tags[found_tag])
 						#logSys.log(5, 'value now: %s' % value)
 						done.append(found_tag)
-						m = t.search(value, m.start())
+						# we need to look back now in case this was an embedded tag
+						# TODO: make it more efficient, this is just a proof of concept
+						start = m.start()
+						for idx in range(m.start()-1, -1, -1):
+							c = value[idx]
+							if c == '>':
+								break
+							elif c == '<':
+								start = idx	  # reconsider
+								break
+						m = t.search(value, start)
 					else:
 						# Missing tags are ok so we just continue on searching.
 						# cInfo can contain aInfo elements like <HOST> and valid shell

--- a/fail2ban/tests/actiontestcase.py
+++ b/fail2ban/tests/actiontestcase.py
@@ -71,6 +71,12 @@ class CommandActionTest(LogCaptureTestCase):
 									'ABC': '123 192.0.2.0',
 									'xyz': '890 123 192.0.2.0',
 								})
+		# obscure embedded case
+		self.assertEqual(CommandAction.substituteRecursiveTags({'A': '<<PREF>HOST>', 'PREF': 'IPV4'}),
+						 {'A': '<IPV4HOST>', 'PREF': 'IPV4'})
+		self.assertEqual(CommandAction.substituteRecursiveTags({'A': '<<PREF>HOST>', 'PREF': 'IPV4', 'IPV4HOST': '1.2.3.4'}),
+						 {'A': '1.2.3.4', 'PREF': 'IPV4', 'IPV4HOST': '1.2.3.4'})
+
 
 	def testReplaceTag(self):
 		aInfo = {


### PR DESCRIPTION
Decided first to show that previously embedded tags worked, apparently just a half way.  As first commit bfc4f5cb8db6ef81f3cbc7d1422278f8acf0d4bc test showed - first test passes and only 2nd one fails since we didn't look back to allow for outside tag to get reconsidered.  Thus 2nd commit 928dfd19846feb5278209dab5912cdea3975c6e1 , although in a cruel fashion addresses that concern.   If you could see how to fit this all in nicely, I think it would be quite nice and possibly allow for new use-cases
