### PR TITLE
Pr 1413: BF for isStarted (should it be just removed?) and centralize reassignment of signal handlers

### DIFF
--- a/fail2ban/server/server.py
+++ b/fail2ban/server/server.py
@@ -87,6 +87,11 @@ class Server:
 		logSys.debug("Caught signal %d. Flushing logs" % signum)
 		self.flushLogs()
 
+	def _rebindSignal(self, s, new):
+		"""Bind new signal handler while storing old one in _prev_signals"""
+		self.__prev_signals[s] = signal.getsignal(s)
+		signal.signal(s, new)
+
 	def start(self, sock, pidfile, force=False, conf={}):
 		# First set the mask to only allow access to owner
 		os.umask(0077)
@@ -120,9 +125,10 @@ class Server:
 
 		# Install signal handlers
 		if _thread_name() == '_MainThread':
-			for s in (signal.SIGTERM, signal.SIGINT, signal.SIGUSR1):
-				self.__prev_signals[s] = signal.getsignal(s)
-				signal.signal(s, self.__sigTERMhandler if s != signal.SIGUSR1 else self.__sigUSR1handler)
+			for s in (signal.SIGTERM, signal.SIGINT):
+				self._rebindSignal(s, self.__sigTERMhandler)
+			self._rebindSignal(signal.SIGUSR1, self.__sigUSR1handler)
+
 		# Ensure unhandled exceptions are logged
 		sys.excepthook = excepthook
 
@@ -490,18 +496,18 @@ class Server:
 				try:
 					handler.flush()
 					handler.close()
-				except (ValueError, KeyError): # pragma: no cover
+				except (ValueError, KeyError):  # pragma: no cover
 					# Is known to be thrown after logging was shutdown once
 					# with older Pythons -- seems to be safe to ignore there
 					# At least it was still failing on 2.6.2-0ubuntu1 (jaunty)
-					if (2,6,3) <= sys.version_info < (3,) or \
-							(3,2) <= sys.version_info:
+					if (2, 6, 3) <= sys.version_info < (3,) or \
+							(3, 2) <= sys.version_info:
 						raise
 			# tell the handler to use this format
 			hdlr.setFormatter(formatter)
 			logger.addHandler(hdlr)
 			# Does not display this message at startup.
-			if not self.__logTarget is None:
+			if self.__logTarget is not None:
 				logSys.info("Start Fail2ban v%s", version.version)
 				logSys.info(
 					"Changed logging target to %s for Fail2ban v%s"
@@ -588,9 +594,7 @@ class Server:
 		# We need to set this in the parent process, so it gets inherited by the
 		# child process, and this makes sure that it is effect even if the parent
 		# terminates quickly.
-		for s in (signal.SIGHUP,):
-			self.__prev_signals[s] = signal.getsignal(s)
-			signal.signal(s, signal.SIG_IGN)
+		self._rebindSignal(signal.SIGHUP, signal.SIG_IGN)
 
 		try:
 			# Fork a child process so the parent can exit.  This will return control

--- a/fail2ban/server/server.py
+++ b/fail2ban/server/server.py
@@ -60,7 +60,7 @@ def _thread_name():
 
 class Server:
 	
-	def __init__(self, daemon = False):
+	def __init__(self, daemon=False):
 		self.__loggingLock = Lock()
 		self.__lock = RLock()
 		self.__jails = Jails()
@@ -377,7 +377,7 @@ class Server:
 		return self.__jails[name].actions.getBanTime()
 	
 	def isStarted(self):
-		self.__asyncServer.isActive()
+		return self.__asyncServer is not None and self.__asyncServer.isActive()
 
 	def isAlive(self, jailnum=None):
 		if jailnum is not None and len(self.__jails) != jailnum:

--- a/fail2ban/tests/servertestcase.py
+++ b/fail2ban/tests/servertestcase.py
@@ -158,6 +158,9 @@ class Transmitter(TransmitterBase):
 	def setUp(self):
 		self.server = TestServer()
 		super(Transmitter, self).setUp()
+		# so far isStarted only tested but not used otherwise
+		# and here we don't really .start server
+		self.assertFalse(self.server.isStarted())
 
 	def testStopServer(self):
 		self.assertEqual(self.transm.proceed(["stop"]), (0, None))
@@ -1004,6 +1007,7 @@ class LoggingTests(LogCaptureTestCase):
 		server = TestServer()
 		try:
 			server.start(sock_name, pidfile_name, force=False)
+			self.assertFalse(server.isStarted())
 			self.assertLogged("Server already running")
 		finally:
 			server.quit()


### PR DESCRIPTION
- [x] **CONSIDER adding a unit test** if your PR resolves an issue

isStarted is not used anywhere and difficult to test for it to return True within the same process ;)
